### PR TITLE
handle potential race with concurrent conn.Close()

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -25,15 +25,19 @@ func (c *Conn) Write(msg []byte) error {
 // Sends a byte-slice to the connected client and triggers the specified event with the data. Returns an error
 // if the connection is already closed.
 func (c *Conn) WriteEvent(typ string, msg []byte) error {
-	if !c.isOpen {
-		return ErrConnectionClosed
-	} else {
-		c.messages <- message{
-			message: msg,
-			typ:     typ,
-		}
-		return nil
-	}
+   for {
+      select {
+      case c.messages <- message{
+         message: msg,
+         typ:     typ,
+      }:
+         return nil
+      default:
+         if !c.isOpen {
+            return ErrConnectionClosed
+         }
+      }
+   }
 }
 
 // Sends a string to the connected client. Returns an error

--- a/conn.go
+++ b/conn.go
@@ -36,6 +36,7 @@ func (c *Conn) WriteEvent(typ string, msg []byte) error {
          if !c.isOpen {
             return ErrConnectionClosed
          }
+         time.Sleep(10*time.Microsecond) // give channel time to unblock
       }
    }
 }

--- a/conn.go
+++ b/conn.go
@@ -3,6 +3,7 @@ package sse
 import (
 	"encoding/json"
 	"encoding/xml"
+	"time"
 )
 
 type Conn struct {


### PR DESCRIPTION
Don't want to close c.messages channel, since sends or close on closed channel will cause a panic.  [Tested with examples plus production code.]
